### PR TITLE
Add background image overlay during dragging in Clip Path Generator

### DIFF
--- a/app/tool/clip-path-generator/components/ClipPathGenerator.tsx
+++ b/app/tool/clip-path-generator/components/ClipPathGenerator.tsx
@@ -2082,6 +2082,22 @@ export default function ClipPathGenerator() {
                 />
               )}
 
+              {/* Full background image with reduced opacity during dragging */}
+              {backgroundImage && (isDragging || isMovingShape) && (
+                <div
+                  className="absolute inset-0 pointer-events-none"
+                  style={{
+                    backgroundImage: `url(${backgroundImage})`,
+                    backgroundSize: 'cover',
+                    backgroundPosition: 'center',
+                    backgroundRepeat: 'no-repeat',
+                    opacity: 0.2, // Very low opacity to serve as a guide
+                    transition: 'opacity 0.2s ease',
+                    zIndex: 1, // Above the grid but below the points
+                  }}
+                />
+              )}
+
               {/* Render the snap grid lines */}
               {gridLines.map(line => (
                 <div


### PR DESCRIPTION
This commit introduces a semi-transparent background image overlay in the Clip Path Generator that appears when users are dragging shapes or moving points. The overlay serves as a visual guide, enhancing the user experience by providing context during interactions. The opacity and transition effects have been set to ensure a smooth visual experience while maintaining focus on the draggable elements.